### PR TITLE
Add field lock supports

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "data/tmp"
 
 [build]
   args_bin = []
-  cmd = "go build -o ./data/tmp/fastschema.exe ./cmd/main.go"
+  cmd = "go build -o ./data/tmp/fastschema.exe ./cmd/"
   bin = "./data/tmp/fastschema.exe"
   full_bin = ""
   delay = 1

--- a/schema/field.go
+++ b/schema/field.go
@@ -26,7 +26,10 @@ type Field struct {
 	Relation   *Relation      `json:"relation,omitempty"`   // relation of the field.
 	DB         *FieldDB       `json:"db,omitempty"`         // db config for the field.
 
+	// SystemField is field created from Go code, not from user schema.
 	IsSystemField bool `json:"is_system_field,omitempty"` // Is a system field.
+	// Lock flag to prevent the field from being modified from API.
+	IsLocked bool `json:"is_locked,omitempty"` // Is a locked field.
 }
 
 // Init initializes the field.
@@ -62,6 +65,7 @@ func (f *Field) Clone() *Field {
 		Sortable:      f.Sortable,
 		Filterable:    f.Filterable,
 		IsSystemField: f.IsSystemField,
+		IsLocked:      f.IsLocked,
 		Relation:      f.Relation.Clone(),
 		DB:            f.DB.Clone(),
 	}
@@ -207,6 +211,7 @@ func MergeFields(f1, f2 *Field) {
 	f1.Sortable = f2.Sortable
 	f1.Filterable = f2.Filterable
 	f1.IsSystemField = f2.IsSystemField
+	f1.IsLocked = f2.IsLocked
 }
 
 func ErrInvalidFieldValue(fieldName string, value any, errs ...error) error {

--- a/schema/relation.go
+++ b/schema/relation.go
@@ -138,6 +138,7 @@ func (r *Relation) CreateFKFields() *Field {
 	fk := r.GetTargetFKColumn()
 	fkField := &Field{
 		IsSystemField: true,
+		IsLocked:      true,
 		Type:          TypeUint64,
 		Name:          fk,
 		Label:         fk,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -80,6 +80,7 @@ func (s *Schema) Init(disableIDColumn bool) error {
 		newIDField.Name = FieldID
 		newIDField.Type = TypeUint64
 		newIDField.IsSystemField = true
+		newIDField.IsLocked = true
 		newIDField.Label = "ID"
 		newIDField.DB = &FieldDB{
 			Attr:      "UNSIGNED",
@@ -116,6 +117,7 @@ func (s *Schema) Init(disableIDColumn bool) error {
 		for _, timeField := range timeFields {
 			tsField := &Field{
 				IsSystemField: true,
+				IsLocked:      true,
 				Type:          TypeTime,
 				Name:          timeField[0],
 				Label:         timeField[1],

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -32,6 +32,7 @@ func TestSchema(t *testing.T) {
 		Filterable:    true,
 		Sortable:      true,
 		IsSystemField: true,
+		IsLocked:      true,
 	}, s.Field(FieldID))
 	assert.True(t, len(s.dbColumns) > 0)
 
@@ -126,39 +127,6 @@ func TestNewSchemaFromJSON(t *testing.T) {
 			}
 		]
 	}`
-
-	// expectedSchema := &Schema{
-	// 	Name:             "test",
-	// 	Namespace:        "test_namespace",
-	// 	LabelFieldName:   "name",
-	// 	DisableTimestamp: true,
-	// 	Fields: []*Field{
-	// 		{
-	// 			Name:          "id",
-	// 			Type:          TypeUint64,
-	// 			Label:         "ID",
-	// 			IsSystemField: true,
-	// 			Unique:        true,
-	// 			Filterable:    true,
-	// 			Sortable:      true,
-	// 			DB: &FieldDB{
-	// 				Attr:      "UNSIGNED",
-	// 				Key:       "UNI",
-	// 				Increment: true,
-	// 			},
-	// 		},
-	// 		{
-	// 			Name:          "name",
-	// 			Type:          TypeString,
-	// 			Label:         "Name",
-	// 			Unique:        true,
-	// 			Sortable:      true,
-	// 			IsSystemField: false,
-	// 		},
-	// 	},
-	// 	IsSystemSchema:   false,
-	// 	IsJunctionSchema: false,
-	// }
 
 	schema, err = NewSchemaFromJSON(jsonData)
 	assert.NoError(t, err)


### PR DESCRIPTION
Add field lock supports to pevent modify a field through API call.
This will also fix: https://github.com/fastschema/fastschema/issues/75