### PR TITLE
feat: Refactor logic register user

### DIFF
--- a/pkg/auth/local.go
+++ b/pkg/auth/local.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/fastschema/fastschema/db"
 	"github.com/fastschema/fastschema/entity"
@@ -95,7 +96,7 @@ func (la *LocalProvider) Register(c fs.Context, payload *Register) (*Activation,
 
 		if _, err = db.Builder[*fs.User](tx).
 			Where(db.EQ("id", user.ID)).
-			Update(c, entity.New().Set("provider_id", string(user.ID))); err != nil {
+			Update(c, entity.New().Set("provider_id", strconv.FormatUint(user.ID, 10))); err != nil {
 			c.Logger().Errorf(MSG_USER_UPDATE_PROVIDER_ID_ERROR, err)
 			return ERR_SAVE_USER
 		}

--- a/pkg/auth/local.go
+++ b/pkg/auth/local.go
@@ -95,14 +95,15 @@ func (la *LocalProvider) Register(c fs.Context, payload *Register) (*Activation,
 
 		if _, err = db.Builder[*fs.User](tx).
 			Where(db.EQ("id", user.ID)).
-			Update(c, entity.New().Set("provider_id", user.ID)); err != nil {
+			Update(c, entity.New().Set("provider_id", string(user.ID))); err != nil {
+			c.Logger().Errorf(MSG_USER_UPDATE_PROVIDER_ID_ERROR, err)
 			return ERR_SAVE_USER
 		}
 
 		user.ProviderID = fmt.Sprintf("%d", user.ID)
 		email, err := CreateActivationEmail(la, user)
 		if err != nil {
-			c.Logger().Error(MSG_CREATE_ACTIVATION_MAIL_ERROR, err)
+			c.Logger().Errorf(MSG_CREATE_ACTIVATION_MAIL_ERROR, err)
 			return ERR_SAVE_USER
 		}
 
@@ -110,7 +111,7 @@ func (la *LocalProvider) Register(c fs.Context, payload *Register) (*Activation,
 
 		return nil
 	}); err != nil {
-		c.Logger().Error(MSG_USER_SAVE_ERROR, err)
+		c.Logger().Errorf(MSG_USER_SAVE_ERROR, err)
 		return nil, ERR_SAVE_USER
 	}
 

--- a/pkg/auth/messages.go
+++ b/pkg/auth/messages.go
@@ -10,21 +10,22 @@ import (
 )
 
 var (
-	MSG_USER_SAVE_ERROR              = "error saving user"
-	MSG_USER_ACTIVATION_ERROR        = "error activating user"
-	MSG_INVALID_TOKEN                = "invalid token"
-	MSG_TOKEN_EXPIRED                = "token expired"
-	MSG_CREATE_ACTIVATION_MAIL_ERROR = "error while creating activation email"
-	MSG_CREATEP_RECOVERY_MAIL_ERROR  = "error while creating recovery email"
-	MSG_INVALID_EMAIL                = "invalid email"
-	MSG_INVALID_PASSWORD             = "invalid password"
-	MSG_INVALID_LOGIN_OR_PASSWORD    = "invalid login or password"
-	MSG_USER_IS_INACTIVE             = "user is inactive"
-	MSG_INVALID_REGISTRATION         = "username, email, password and confirm_password are required"
-	MSG_SEND_ACTIVATION_EMAIL_ERROR  = "error while sending activation email"
-	MSG_MAILER_NOT_SET               = "mailer is not set"
-	MSG_CHECKING_USER_ERROR          = "error checking user"
-	MSG_USER_EXISTS                  = "user already exists"
+	MSG_USER_SAVE_ERROR               = "error saving user: %w"
+	MSG_USER_ACTIVATION_ERROR         = "error activating user"
+	MSG_INVALID_TOKEN                 = "invalid token"
+	MSG_TOKEN_EXPIRED                 = "token expired"
+	MSG_CREATE_ACTIVATION_MAIL_ERROR  = "error while creating activation email: %w"
+	MSG_USER_UPDATE_PROVIDER_ID_ERROR = "error while update provider id: %w"
+	MSG_CREATEP_RECOVERY_MAIL_ERROR   = "error while creating recovery email"
+	MSG_INVALID_EMAIL                 = "invalid email"
+	MSG_INVALID_PASSWORD              = "invalid password"
+	MSG_INVALID_LOGIN_OR_PASSWORD     = "invalid login or password"
+	MSG_USER_IS_INACTIVE              = "user is inactive"
+	MSG_INVALID_REGISTRATION          = "username, email, password and confirm_password are required"
+	MSG_SEND_ACTIVATION_EMAIL_ERROR   = "error while sending activation email"
+	MSG_MAILER_NOT_SET                = "mailer is not set"
+	MSG_CHECKING_USER_ERROR           = "error checking user"
+	MSG_USER_EXISTS                   = "user already exists"
 
 	ERR_SAVE_USER     = errors.InternalServerError(MSG_USER_SAVE_ERROR)
 	ERR_INVALID_TOKEN = errors.BadRequest(MSG_INVALID_TOKEN)


### PR DESCRIPTION
Fix bug: Cannot register user by path `/api/auth/local/register`

Reason: provider_id updating fails due to conflict type 

```
2025-06-02T17:00:09.776014455+07:00	error	auth/local.go:101	failed to encode args[0]: unable to encode 0x10 into text format for varchar (OID 1043): cannot find encode plan	{"trace_id": "33fd8810-b80c-4024-b7b8-3324f3e2adb5"}

```