### PR TITLE
ci: upgrade to golangci/golangci-lint-action@v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           args: --verbose
 

--- a/pkg/entdbadapter/db.go
+++ b/pkg/entdbadapter/db.go
@@ -219,7 +219,7 @@ func NewDBAdapter(
 			return nil, err
 		}
 
-		a.typesModels[s.SystemSchema.RType] = typeModel
+		a.typesModels[s.RType] = typeModel
 	}
 
 	return a, nil

--- a/pkg/rclonefs/base.go
+++ b/pkg/rclonefs/base.go
@@ -108,7 +108,7 @@ func (r *BaseRcloneDisk) PutMultipart(
 }
 
 func (r *BaseRcloneDisk) Delete(ctx context.Context, filePath string) error {
-	obj, err := r.Fs.NewObject(ctx, filePath)
+	obj, err := r.NewObject(ctx, filePath)
 
 	if err != nil {
 		return err

--- a/pkg/rclonefs/local.go
+++ b/pkg/rclonefs/local.go
@@ -40,7 +40,7 @@ func NewLocal(config *RcloneLocalConfig) (fs.Disk, error) {
 		},
 	}
 
-	rl.BaseRcloneDisk.GetURL = rl.URL
+	rl.GetURL = rl.URL
 
 	if err := os.MkdirAll(config.Root, os.ModePerm); err != nil {
 		return nil, err

--- a/pkg/rclonefs/s3.go
+++ b/pkg/rclonefs/s3.go
@@ -58,7 +58,7 @@ func NewS3(config *RcloneS3Config) (fs.Disk, error) {
 		},
 	}
 
-	rs3.BaseRcloneDisk.GetURL = rs3.URL
+	rs3.GetURL = rs3.URL
 	cfgMap := &configmap.Simple{}
 	cfgMap.Set("provider", config.Provider)
 	cfgMap.Set("bucket", config.Bucket)

--- a/pkg/restfulresolver/context.go
+++ b/pkg/restfulresolver/context.go
@@ -125,7 +125,7 @@ func (c *Context) Hostname() string {
 }
 
 func (c *Context) Base() string {
-	return c.Ctx.Protocol() + "://" + c.Ctx.Hostname()
+	return c.Protocol() + "://" + c.Ctx.Hostname()
 }
 
 func (c *Context) Method() string {
@@ -154,7 +154,7 @@ func (c *Context) Status(v int) *Context {
 }
 
 func (c *Context) Local(key string, value ...any) (val any) {
-	return c.Ctx.Locals(key, value...)
+	return c.Locals(key, value...)
 }
 
 func (c *Context) Logger() logger.Logger {
@@ -179,15 +179,15 @@ func (c *Context) JSON(v any) error {
 
 func (c *Context) Header(key string, vals ...string) string {
 	if len(vals) > 0 {
-		c.Ctx.Set(key, vals[0])
+		c.Set(key, vals[0])
 		return vals[0]
 	}
 
-	return c.Ctx.Get(key)
+	return c.Get(key)
 }
 
 func (c *Context) Cookie(name string, values ...*Cookie) string {
-	cookieValue := c.Ctx.Cookies(name)
+	cookieValue := c.Cookies(name)
 	if len(values) > 0 {
 		v := values[0]
 		cookie := fiber.Cookie{
@@ -221,12 +221,12 @@ func (c *Context) Redirect(path string) error {
 
 func (c *Context) Bind(v any) error {
 	// if there is no content type header, we assume it's JSON
-	if c.Ctx.Get("Content-Type") == "" {
-		c.Ctx.Set("Content-Type", "application/json")
+	if c.Get("Content-Type") == "" {
+		c.Set("Content-Type", "application/json")
 		c.Ctx.Request().Header.Set("Content-Type", "application/json")
 	}
 
-	return c.Ctx.BodyParser(v)
+	return c.BodyParser(v)
 }
 
 func (c *Context) Files() ([]*fs.File, error) {

--- a/pkg/restfulresolver/resource.go
+++ b/pkg/restfulresolver/resource.go
@@ -91,7 +91,7 @@ func (r *RestfulResolver) Start(address string) error {
 }
 
 func (r *RestfulResolver) Shutdown() error {
-	return r.server.App.Shutdown()
+	return r.server.Shutdown()
 }
 
 func RegisterResourceRoutes(

--- a/pkg/restfulresolver/server_test.go
+++ b/pkg/restfulresolver/server_test.go
@@ -123,7 +123,7 @@ func TestServerListen(t *testing.T) {
 		server2 := restfulresolver.New(config)
 		err := server2.Listen(":8080")
 		assert.Error(t, err)
-		assert.NoError(t, server.App.Shutdown())
+		assert.NoError(t, server.Shutdown())
 	}()
 	err := server.Listen(":8080")
 	assert.NoError(t, err)

--- a/pkg/zaplogger/zap.go
+++ b/pkg/zaplogger/zap.go
@@ -91,7 +91,7 @@ func NewZapLogger(config *logger.Config) (_ *ZapLogger, err error) {
 func (l *ZapLogger) WithContext(context logger.LogContext, callerSkips ...int) logger.Logger {
 	callerSkips = append(callerSkips, 0)
 	return &ZapLogger{
-		Logger:     l.Logger.WithOptions(zap.AddCallerSkip(callerSkips[0])),
+		Logger:     l.WithOptions(zap.AddCallerSkip(callerSkips[0])),
 		LogContext: context,
 		config:     l.config,
 	}

--- a/plugins/config.go
+++ b/plugins/config.go
@@ -38,7 +38,7 @@ func (p *ConfigActions) AddSchemas(schemas ...map[string]any) error {
 		newSchemas = append(newSchemas, ss)
 	}
 
-	p.Config.SystemSchemas = append(p.Config.SystemSchemas, newSchemas...)
+	p.SystemSchemas = append(p.SystemSchemas, newSchemas...)
 
 	return nil
 }


### PR DESCRIPTION
- Upgrade to `golangci/golangci-lint-action@v8`
- Fix `golanglint-ci` warning