### PR TITLE
Better mail configuration from an enviroment variable (fixes issue #286)

### DIFF
--- a/init.go
+++ b/init.go
@@ -478,7 +478,7 @@ func (a *App) createMailClients() (err error) {
 		mail := utils.Env("FASTSCHEMA_MAIL")
 		if mail != "" {
 			if err := json.Unmarshal([]byte(mail), &a.config.MailConfig); err != nil {
-				return fmt.Errorf("error parsing the (Json) FASTSCHEMA_MAIL environment variable: %v", err)
+				return fmt.Errorf("error parsing the (Json) FASTSCHEMA_MAIL environment variable: %W", err)
 			}
 		} else {
 			a.config.MailConfig = &fs.MailConfig{}

--- a/init.go
+++ b/init.go
@@ -475,9 +475,10 @@ func (a *App) createDBClient() (err error) {
 
 func (a *App) createMailClients() (err error) {
 	if a.config.MailConfig == nil {
-		if utils.Env("MAIL") != "" {
-			if err := json.Unmarshal([]byte(utils.Env("MAIL")), &a.config.MailConfig); err != nil {
-				return err
+		mail := utils.Env("FASTSCHEMA_MAIL")
+		if mail != "" {
+			if err := json.Unmarshal([]byte(mail), &a.config.MailConfig); err != nil {
+				return fmt.Errorf("error parsing the (Json) FASTSCHEMA_MAIL environment variable: %v", err)
 			}
 		} else {
 			a.config.MailConfig = &fs.MailConfig{}


### PR DESCRIPTION
1) Use FASTSCHEMA_MAIL instead of MAIL environment variable, in order to
avoid possible conflicts with other applications.
2) If there is an error parsing the Json content of that variable, return an error with context to help the user debug the issue. 
3) Avoid calling the utils.Env function twice.