### PR TITLE
feat: SSLMode option for Postgres driver

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -149,6 +149,9 @@ type Config struct {
 	DisableForeignKeys bool          `json:"disable_foreign_keys"`
 	UseSoftDeletes     bool          `json:"use_soft_deletes"`
 	Hooks              func() *Hooks `json:"-"`
+	// SSLMode is only applicable for pgx (Postgres) driver.
+	// Valid values: disable, allow, prefer, require (verify-ca, verify-full not supported). Defaults to prefer.
+	SSLMode string `json:"ssl_mode"`
 }
 
 func (c *Config) Clone() *Config {
@@ -164,6 +167,7 @@ func (c *Config) Clone() *Config {
 		MigrationDir:       c.MigrationDir,
 		IgnoreMigration:    c.IgnoreMigration,
 		DisableForeignKeys: c.DisableForeignKeys,
+		SSLMode:            c.SSLMode,
 		Hooks:              c.Hooks,
 	}
 }

--- a/init.go
+++ b/init.go
@@ -430,6 +430,7 @@ func (a *App) createDBClient() (err error) {
 			LogQueries:         utils.Env("DB_LOGGING", "false") == "true",
 			DisableForeignKeys: utils.Env("DB_DISABLE_FOREIGN_KEYS", "false") == "true",
 			UseSoftDeletes:     utils.Env("DB_USE_SOFT_DELETES", "false") == "true",
+			SSLMode:            utils.Env("DB_SSLMODE"),
 		}
 	}
 
@@ -451,6 +452,11 @@ func (a *App) createDBClient() (err error) {
 
 	if a.config.DBConfig.MigrationDir == "" {
 		a.config.DBConfig.MigrationDir = a.migrationDir
+	}
+
+	pgxValidSSLModes := []string{"disable", "allow", "prefer", "require"}
+	if a.config.DBConfig.Driver == "pgx" && a.config.DBConfig.SSLMode != "" && !utils.Contains(pgxValidSSLModes, a.config.DBConfig.SSLMode) {
+		return fmt.Errorf("invalid ssl_mode %q: must be one of %v", a.config.DBConfig.SSLMode, pgxValidSSLModes)
 	}
 
 	// If driver is sqlite and the DB_NAME (file path) is not set,

--- a/pkg/entdbadapter/common.go
+++ b/pkg/entdbadapter/common.go
@@ -129,13 +129,18 @@ func CreateDBDSN(config *db.Config) string {
 	}
 
 	if config.Driver == "pgx" {
+		sslMode := config.SSLMode
+		if sslMode == "" {
+			sslMode = "prefer"
+		}
 		dsn = fmt.Sprintf(
-			"host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
+			"host=%s port=%s user=%s dbname=%s password=%s sslmode=%s",
 			config.Host,
 			config.Port,
 			config.User,
 			config.Name,
 			config.Pass,
+			sslMode,
 		)
 	}
 


### PR DESCRIPTION
This makes Postgres driver accepts `DB_SSLMODE` env var, or set  `.SSLMode` in config block.

Ref https://github.com/fastschema/fastschema/issues/199