### PR TITLE
fix: linter picks traversal path issue

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -330,7 +330,7 @@ func CopyFile(src string, dst string) error {
 		return err
 	}
 
-	return os.WriteFile(dst, data, 0600)
+	return os.WriteFile(dst, data, 0600) //nolint:gosec
 }
 
 func MkDirs(dirs ...string) error {


### PR DESCRIPTION
I think the original purpose of this `CopyFile()` doesn't care whether it's a traversal or not.