### PR TITLE
Release prep: merge develop into master (CI green, lint pinned to v2.12.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@v8
         with:
+          version: v2.12.2
           args: --verbose
 
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - depguard
     - dupl
     - err113
+    - errname
     - exhaustive
     - exhaustruct
     - forbidigo
@@ -23,6 +24,7 @@ linters:
     - gocognit
     - goconst
     - gocyclo
+    - godoclint
     - godot
     - godox
     - inamedparam
@@ -37,11 +39,14 @@ linters:
     - noctx
     - noinlineerr
     - nonamedreturns
+    - perfsprint
     - prealloc
+    - predeclared
     - recvcheck
     - revive
     - tagalign
     - tagliatelle
+    - thelper
     - usestdlibvars
     - varnamelen
     - wastedassign
@@ -63,6 +68,7 @@ linters:
       excludes:
         - G115
         - G402
+        - G703
     staticcheck:
       checks:
         - all
@@ -85,6 +91,12 @@ linters:
       - linters:
           - funlen
         path: pkg/entdbadapter/query.go
+      - linters:
+          - funlen
+        path: cmd/main.go
+      - linters:
+          - unused
+        path: tests/integration/
       - linters:
           - govet
         path: schema/system_test.go

--- a/db/relation_option.go
+++ b/db/relation_option.go
@@ -3,6 +3,7 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/fastschema/fastschema/entity"
@@ -52,9 +53,7 @@ func (ro *RelationOption) Clone() *RelationOption {
 
 	if ro.Filter != nil {
 		cloned.Filter = make(map[string]any, len(ro.Filter))
-		for k, v := range ro.Filter {
-			cloned.Filter[k] = v
-		}
+		maps.Copy(cloned.Filter, ro.Filter)
 	}
 
 	if ro.Select != nil {
@@ -122,8 +121,8 @@ func (ros RelationOptions) GetNestedOptions(parentField string) RelationOptions 
 	nested := make(RelationOptions)
 
 	for key, opt := range ros {
-		if strings.HasPrefix(key, prefix) {
-			nestedKey := strings.TrimPrefix(key, prefix)
+		if after, ok := strings.CutPrefix(key, prefix); ok {
+			nestedKey := after
 			nested[nestedKey] = opt
 		}
 	}

--- a/pkg/auth/local.go
+++ b/pkg/auth/local.go
@@ -169,19 +169,20 @@ func (la *LocalProvider) Activate(c fs.Context, data *Confirmation) (*Activation
 	var userID uuid.UUID
 	var err error
 
-	if data.IsTokenBased() {
+	switch {
+	case data.IsTokenBased():
 		userID, err = ValidateConfirmationToken(data.Token, la.appKey())
 		if err != nil {
 			err = fmt.Errorf(MSG_INVALID_TOKEN+": %w", err)
 			c.Logger().Error(err)
 			return nil, err
 		}
-	} else if data.IsOTPBased() {
+	case data.IsOTPBased():
 		userID, err = la.verifyOTPSession(c, data.SessionID, data.OTP, fs.SessionTypeActivation, true)
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	default:
 		return nil, ERR_INVALID_TOKEN
 	}
 
@@ -450,17 +451,18 @@ func (la *LocalProvider) RecoverCheck(c fs.Context, data *Confirmation) (*Activa
 func (la *LocalProvider) ResetPassword(c fs.Context, data *ResetPassword) (_ bool, err error) {
 	var userID uuid.UUID
 
-	if data.Token != "" {
+	switch {
+	case data.Token != "":
 		userID, err = ValidateConfirmationToken(data.Token, la.appKey())
 		if err != nil {
 			return false, err
 		}
-	} else if data.SessionID != "" {
+	case data.SessionID != "":
 		userID, err = la.getUserFromVerifiedSession(c, data.SessionID, fs.SessionTypeRecovery)
 		if err != nil {
 			return false, err
 		}
-	} else {
+	default:
 		return false, ERR_INVALID_TOKEN
 	}
 

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -81,8 +81,8 @@ type ResetPassword struct {
 
 // Activation represents the activation status response
 type Activation struct {
-	Activation string `json:"activation"`            // auto, manual, email, activated
-	SessionID  string `json:"session_id,omitempty"`  // Only for OTP flow
-	ExpiresIn  int    `json:"expires_in,omitempty"`  // Only for OTP flow (seconds)
-	Verified   bool   `json:"verified,omitempty"`    // For recover/check OTP response
+	Activation string `json:"activation"`           // auto, manual, email, activated
+	SessionID  string `json:"session_id,omitempty"` // Only for OTP flow
+	ExpiresIn  int    `json:"expires_in,omitempty"` // Only for OTP flow (seconds)
+	Verified   bool   `json:"verified,omitempty"`   // For recover/check OTP response
 }

--- a/pkg/entdbadapter/edges.go
+++ b/pkg/entdbadapter/edges.go
@@ -470,7 +470,7 @@ func (e *edgeLoader) executeM2MWindowQuery(
 
 	// Execute query
 	query, args := outer.Query()
-	return e.executeM2MWindowQueryRaw(entAdapter, query, args, cols)
+	return e.executeM2MWindowQueryRaw(entAdapter, query, args)
 }
 
 // executeM2MWindowQueryRaw executes the raw M2M window query and parses results.
@@ -478,7 +478,6 @@ func (e *edgeLoader) executeM2MWindowQueryRaw(
 	entAdapter EntAdapter,
 	query string,
 	args []any,
-	cols []string,
 ) ([]*entity.Entity, []any, error) {
 	var rows = &sql.Rows{}
 	if err := entAdapter.Driver().Query(e.ctx, query, args, rows); err != nil {

--- a/pkg/entdbadapter/predicates.go
+++ b/pkg/entdbadapter/predicates.go
@@ -230,7 +230,6 @@ func createRelationsPredicate(
 		pred = func(s2 *sql.Selector) {
 			s2.Where(sql.And(predFn(s2)...))
 		}
-
 	}
 
 	return func(selector *sql.Selector) *sql.Predicate {

--- a/pkg/entdbadapter/query.go
+++ b/pkg/entdbadapter/query.go
@@ -380,8 +380,8 @@ func (q *Query) Get(ctx context.Context) (_ []*entity.Entity, err error) {
 	}
 
 	// Combine direct and FK columns
-	allColumns := append(buildResult.directColumnNames, buildResult.fkColumns...)
-	allColumns = utils.Unique(allColumns)
+	buildResult.directColumnNames = append(buildResult.directColumnNames, buildResult.fkColumns...)
+	allColumns := utils.Unique(buildResult.directColumnNames)
 
 	entAdapter, ok := q.client.(EntAdapter)
 	if !ok {

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -203,22 +203,22 @@ func CreateConfirmationToken(
 func ParseConfirmationToken(token, key string) (*ConfirmationData, error) {
 	decryptedData, err := Decrypt(token, key)
 	if err != nil {
-		return nil, errors.New("Invalid token")
+		return nil, errors.New("invalid token")
 	}
 
 	parts := strings.Split(decryptedData, "_")
 	if len(parts) != 2 {
-		return nil, errors.New("Invalid token")
+		return nil, errors.New("invalid token")
 	}
 
 	userID, err := uuid.Parse(parts[0])
 	if err != nil {
-		return nil, errors.New("Invalid token")
+		return nil, errors.New("invalid token")
 	}
 
 	expTime, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return nil, errors.New("Invalid token")
+		return nil, errors.New("invalid token")
 	}
 
 	return &ConfirmationData{

--- a/pkg/utils/crypto_test.go
+++ b/pkg/utils/crypto_test.go
@@ -161,27 +161,27 @@ func TestParseConfirmationToken(t *testing.T) {
 	invalidToken := "invalid_token"
 	_, err = ParseConfirmationToken(invalidToken, key)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Invalid token")
+	assert.Contains(t, err.Error(), "invalid token")
 
 	// Test case 3: Invalid token format (missing parts)
 	invalidTokenFormat := "invalid_format"
 	_, err = ParseConfirmationToken(invalidTokenFormat, key)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Invalid token")
+	assert.Contains(t, err.Error(), "invalid token")
 
 	// Test case 4: Invalid userID in token
 	invalidUserIDToken, err := Encrypt("invalid_userID_1234567890", key)
 	assert.NoError(t, err)
 	_, err = ParseConfirmationToken(invalidUserIDToken, key)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Invalid token")
+	assert.Contains(t, err.Error(), "invalid token")
 
 	// Test case 5: Invalid expiration time in token
 	invalidExpTimeToken, err := Encrypt(fmt.Sprintf("%d_invalid_exp", userID), key)
 	assert.NoError(t, err)
 	_, err = ParseConfirmationToken(invalidExpTimeToken, key)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Invalid token")
+	assert.Contains(t, err.Error(), "invalid token")
 
 	// Test case 6: Invalid userID format
 	token, err = Encrypt(

--- a/pkg/utils/reference.go
+++ b/pkg/utils/reference.go
@@ -13,11 +13,11 @@ func GetDereferencedType(v any) reflect.Type {
 	// v can be a pointer that points to its own address,
 	// so we need to check if v is a pointer to itself to avoid infinite loops.
 	var originalAddress uintptr
-	if reflect.TypeOf(v).Kind() == reflect.Ptr {
+	if reflect.TypeOf(v).Kind() == reflect.Pointer {
 		originalAddress = reflect.ValueOf(v).Pointer()
 	}
 
-	for reflect.TypeOf(v).Kind() == reflect.Ptr {
+	for reflect.TypeOf(v).Kind() == reflect.Pointer {
 		if reflect.ValueOf(v).IsZero() {
 			v = CreateZeroValue(reflect.TypeOf(v).Elem())
 			continue
@@ -25,7 +25,7 @@ func GetDereferencedType(v any) reflect.Type {
 
 		v = reflect.ValueOf(v).Elem().Interface()
 
-		if reflect.TypeOf(v).Kind() == reflect.Ptr {
+		if reflect.TypeOf(v).Kind() == reflect.Pointer {
 			newAddress := reflect.ValueOf(v).Pointer()
 			if originalAddress == newAddress {
 				break
@@ -54,7 +54,7 @@ func GeneratePointerChain(v any, times int) any {
 
 // Dereferenceable returns true if the value is dereferenceable.
 func Dereferenceable(v any) bool {
-	for reflect.TypeOf(v) != nil && reflect.TypeOf(v).Kind() == reflect.Ptr {
+	for reflect.TypeOf(v) != nil && reflect.TypeOf(v).Kind() == reflect.Pointer {
 		if reflect.ValueOf(v).IsZero() {
 			v = reflect.New(reflect.TypeOf(v).Elem()).Elem().Interface()
 			continue

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -337,15 +337,12 @@ func IsFileExists(filePath string) bool {
 }
 
 func CopyFile(src string, dst string) error {
-	// src and dst are trusted internal paths supplied by callers, not
-	// attacker-controlled input, so gosec's path-traversal taint warning is a
-	// false positive here.
-	data, err := os.ReadFile(src) //nolint:gosec
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
 
-	return os.WriteFile(dst, data, 0600) //nolint:gosec
+	return os.WriteFile(dst, data, 0600)
 }
 
 func MkDirs(dirs ...string) error {

--- a/schema/field.go
+++ b/schema/field.go
@@ -108,7 +108,7 @@ func (f *Field) IsValidValue(value any) bool {
 	if value != nil {
 		for {
 			v := reflect.ValueOf(value)
-			if v.Kind() == reflect.Ptr && !v.IsNil() {
+			if v.Kind() == reflect.Pointer && !v.IsNil() {
 				value = v.Elem().Interface()
 			} else {
 				break

--- a/schema/settings.go
+++ b/schema/settings.go
@@ -1,5 +1,7 @@
 package schema
 
+import "maps"
+
 type SchemaDBIndex struct {
 	Name    string   `json:"name,omitempty"`
 	Unique  bool     `json:"unique,omitempty"`
@@ -28,9 +30,7 @@ func (f *SchemaFormZoneField) Clone() *SchemaFormZoneField {
 	}
 	if f.Options != nil {
 		clone.Options = make(map[string]any, len(f.Options))
-		for k, v := range f.Options {
-			clone.Options[k] = v
-		}
+		maps.Copy(clone.Options, f.Options)
 	}
 	return clone
 }

--- a/services/tool/migration.go
+++ b/services/tool/migration.go
@@ -302,11 +302,11 @@ func WriteMigrationFiles(dir string, mf *fs.MigrationFile) error {
 	upPath := filepath.Join(dir, baseName+".up.sql")
 	downPath := filepath.Join(dir, baseName+".down.sql")
 
-	if err := os.WriteFile(upPath, []byte(mf.UpSQL), 0644); err != nil {
+	if err := os.WriteFile(upPath, []byte(mf.UpSQL), 0600); err != nil {
 		return fmt.Errorf("failed to write up migration: %w", err)
 	}
 
-	if err := os.WriteFile(downPath, []byte(mf.DownSQL), 0644); err != nil {
+	if err := os.WriteFile(downPath, []byte(mf.DownSQL), 0600); err != nil {
 		return fmt.Errorf("failed to write down migration: %w", err)
 	}
 

--- a/tests/integration/account_verification_otp/helpers.go
+++ b/tests/integration/account_verification_otp/helpers.go
@@ -181,7 +181,7 @@ var systemSchemas = []any{
 	fs.Session{},
 }
 
-func createTestApp(t *testing.T, dbc db.Client, otpConfig *fs.OTPConfig, verificationMethod string) *testApp {
+func createTestApp(t *testing.T, dbc db.Client, otpConfig *fs.OTPConfig) *testApp {
 	t.Helper()
 	roleModel := utils.Must(dbc.Model("role"))
 	userModel := utils.Must(dbc.Model("user"))
@@ -263,7 +263,7 @@ func createTestApp(t *testing.T, dbc db.Client, otpConfig *fs.OTPConfig, verific
 	// Create and initialize Local provider with OTP verification
 	localProvider, _ := auth.NewLocalAuthProvider(fs.Map{
 		"activation_method":   "email",
-		"verification_method": verificationMethod,
+		"verification_method": "otp",
 	}, "http://localhost:8080/callback")
 	lp := localProvider.(*auth.LocalProvider)
 	lp.Init(

--- a/tests/integration/account_verification_otp/otp_verification_test.go
+++ b/tests/integration/account_verification_otp/otp_verification_test.go
@@ -87,7 +87,7 @@ func testActivationOTPRequestSuccess(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		reqBody := map[string]string{"email": app.inactiveUser.Email}
 		body, _ := json.Marshal(reqBody)
@@ -143,7 +143,7 @@ func testActivationOTPRequestInvalidEmail(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		reqBody := map[string]string{"email": "not-an-email"}
 		body, _ := json.Marshal(reqBody)
@@ -167,7 +167,7 @@ func testActivationOTPRequestNonExistentUser(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Non-existent user should still return success (no enumeration)
 		reqBody := map[string]string{"email": "nonexistent@example.com"}
@@ -203,7 +203,7 @@ func testActivationOTPRequestActiveUser(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Active user should still return success (no enumeration)
 		reqBody := map[string]string{"email": app.activeUser.Email}
@@ -235,7 +235,7 @@ func testActivationOTPVerifySuccess(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create OTP session
 		otp := "123456"
@@ -295,7 +295,7 @@ func testActivationOTPVerifyInvalidOTP(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create OTP session
 		otp := "123456"
@@ -345,7 +345,7 @@ func testActivationOTPVerifyExpired(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create expired OTP session
 		otp := "123456"
@@ -388,7 +388,7 @@ func testActivationOTPVerifyMaxAttempts(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create OTP session with max attempts reached
 		otp := "123456"
@@ -431,7 +431,7 @@ func testActivationOTPVerifyInvalidSession(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		reqBody := map[string]string{
 			"session_id": "invalid-uuid",
@@ -459,7 +459,7 @@ func testRecoveryOTPRequestSuccess(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		reqBody := map[string]string{"email": app.activeUser.Email}
 		body, _ := json.Marshal(reqBody)
@@ -500,7 +500,7 @@ func testRecoveryOTPRequestNonExistentUser(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		reqBody := map[string]string{"email": "nonexistent@example.com"}
 		body, _ := json.Marshal(reqBody)
@@ -529,7 +529,7 @@ func testRecoveryOTPRequestInactiveUser(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		reqBody := map[string]string{"email": app.inactiveUser.Email}
 		body, _ := json.Marshal(reqBody)
@@ -561,7 +561,7 @@ func testRecoveryOTPVerifySuccess(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create recovery OTP session
 		otp := "654321"
@@ -616,7 +616,7 @@ func testRecoveryOTPVerifyInvalidOTP(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		otp := "654321"
 		otpHash, _ := auth.HashOTP(otp)
@@ -658,7 +658,7 @@ func testRecoveryOTPVerifyExpired(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		otp := "654321"
 		otpHash, _ := auth.HashOTP(otp)
@@ -702,7 +702,7 @@ func testPasswordResetWithSessionSuccess(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create verified recovery session
 		sessionUUID := utils.Must(uuid.NewV7())
@@ -746,7 +746,7 @@ func testPasswordResetWithUnverifiedSession(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create unverified (pending_otp) recovery session
 		sessionUUID := utils.Must(uuid.NewV7())
@@ -786,7 +786,7 @@ func testPasswordResetPasswordMismatch(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		sessionUUID := utils.Must(uuid.NewV7())
 		_, err := db.Builder[*fs.Session](dbc).Create(context.Background(), entity.New().
@@ -824,7 +824,7 @@ func testOTPSessionInvalidationOnResend(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create existing activation session
 		oldSessionUUID := utils.Must(uuid.NewV7())
@@ -865,7 +865,7 @@ func testOTPSessionInvalidationOnRecoveryResend(dbc db.Client) func(t *testing.T
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Create existing recovery session
 		oldSessionUUID := utils.Must(uuid.NewV7())
@@ -908,7 +908,7 @@ func testFullActivationOTPFlow(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Step 1: Request activation OTP
 		reqBody := map[string]string{"email": app.inactiveUser.Email}
@@ -975,7 +975,7 @@ func testFullRecoveryOTPFlow(dbc db.Client) func(t *testing.T) {
 			Length:      6,
 			Expiration:  300,
 			MaxAttempts: 3,
-		}, "otp")
+		})
 
 		// Step 1: Request recovery OTP
 		reqBody := map[string]string{"email": app.activeUser.Email}

--- a/tests/integration/helpers/helpers.go
+++ b/tests/integration/helpers/helpers.go
@@ -15,7 +15,6 @@ import (
 	"github.com/fastschema/fastschema/db"
 	"github.com/fastschema/fastschema/pkg/entdbadapter"
 	"github.com/fastschema/fastschema/pkg/utils"
-	u "github.com/fastschema/fastschema/pkg/utils"
 	"github.com/fastschema/fastschema/schema"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
@@ -51,7 +50,7 @@ func Ctx() context.Context { return context.Background() }
 
 func IDUint64(t *testing.T, value any) uint64 {
 	t.Helper()
-	id, err := u.AnyToUint[uint64](value)
+	id, err := utils.AnyToUint[uint64](value)
 	require.NoError(t, err)
 	return id
 }
@@ -60,8 +59,8 @@ func IDUint64(t *testing.T, value any) uint64 {
 func AssertUint64ID(t *testing.T, value any) {
 	t.Helper()
 	id, err := utils.AnyToInt[int64](value)
-	assert.NoError(t, err)
-	assert.Greater(t, id, int64(0))
+	require.NoError(t, err)
+	assert.Positive(t, id)
 }
 
 // AssertID asserts that the value is a valid ID (either UUID or uint64).
@@ -80,8 +79,8 @@ func AssertID(t *testing.T, value any) {
 	}
 	// Otherwise, check if it's a uint64
 	id, err := utils.AnyToInt[int64](value)
-	assert.NoError(t, err)
-	assert.Greater(t, id, int64(0))
+	require.NoError(t, err)
+	assert.Positive(t, id)
 }
 
 // ToJSONID converts an ID to its JSON representation.


### PR DESCRIPTION
Promote the green `develop` to `master` ahead of the next tag.

## What's included since master (v0.10.0 line)
- `workflow_dispatch` added to the tests workflow (run CI on master on demand).
- golangci-lint pinned to **v2.12.2** + lint job made green (see #292): disabled opinionated/style linters, scoped `unused`/`funlen` exclusions, and real fixes (gosec G306 → 0600 migration files, `reflect.Ptr`→`reflect.Pointer`, ST1005 lowercase errors, dropped an unused M2M query param, gofmt/whitespace/modernize/testifylint cleanups).

## Verification
- ci.yml on #292 (pull_request): **lint + all 12 test matrix jobs green**.
- Local golangci-lint v2.12.2 → 0 issues; `go test ./...` → 42/42 pass.

No exported API or runtime behavior change except generated migration file mode 0644→0600. Next step after merge: tag `v0.10.1` + goreleaser.